### PR TITLE
[조대원] 질문 리스트 불러오기, 유저카드 컴포넌트 수정

### DIFF
--- a/src/components/Qcard.jsx
+++ b/src/components/Qcard.jsx
@@ -12,7 +12,7 @@ const Card = styled.div`
     padding: 20px;
   }
 
-  > strong {
+  strong {
     display: block;
     margin-top: 12px;
     font-size: 20px;
@@ -34,7 +34,7 @@ const Card = styled.div`
 function Qcard({ profile, nickName, question = 0, id }) {
   return (
     <Card>
-      <Link to={`/post/${id}/answer`} title="홈으로">
+      <Link to={`/post/${id}`} title={`${nickName}님의 질문으로 이동`}>
         <div className="profile">
           <CircleImage src={profile} sizes="60px" />
         </div>

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Qcard from '../components/Qcard';
 import Dropdown from '../components/Dropdown/Dropdown';
 import CustomMenu from '../components/Dropdown/Custommenu';
@@ -130,6 +130,31 @@ const PagenationWrap = styled.div`
 
 function List() {
   const [label, setLabel] = useState('이름순');
+  const [list, setList] = useState([]);
+
+  async function getData() {
+    try {
+      const response = await fetch(
+        'https://openmind-api.vercel.app/19-9/subjects/'
+      );
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.error('에러 발생:', error);
+    }
+  }
+
+  useEffect(() => {
+    async function fetchData() {
+      const data = await getData();
+      // console.log(data);
+      // console.log(data.previous);
+      // console.log(data.next);
+      // console.log(data.count);
+      setList(data.results || []);
+    }
+    fetchData();
+  }, []);
 
   return (
     <ListWrap>
@@ -151,21 +176,18 @@ function List() {
         </div>
 
         <QList>
-          <li>
-            <Qcard />
-          </li>
-          <li>
-            <Qcard />
-          </li>
-          <li>
-            <Qcard />
-          </li>
-          <li>
-            <Qcard />
-          </li>
-          <li>
-            <Qcard />
-          </li>
+          {list.map((item) => {
+            return (
+              <li key={item.id}>
+                <Qcard
+                  profile={item.imageSource}
+                  nickName={item.name}
+                  question={item.questionCount}
+                  id={item.id}
+                />
+              </li>
+            );
+          })}
         </QList>
 
         <PagenationWrap>페이지네이션</PagenationWrap>


### PR DESCRIPTION
## 📝 요약(Summary)

질문 리스트 불러오기, 유저카드 컴포넌트 링크 및 스타일 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- 질문리스트를 가져올 수 있도록 async await try catch를 이용했습니다.
- 유저 카드 클릭시 이동하는 링크 및 title을 수정했습니다.
- 유저 카드의 작성자 부분이 이상하게 나와서 일부 수정했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
