### PR TITLE
[이동국] reaction, 전체 삭제하기 API 기능 적용 #56-1

### DIFF
--- a/src/components/Reaction.jsx
+++ b/src/components/Reaction.jsx
@@ -4,6 +4,7 @@ import likeActiveIco from '../assets/ico_thumbs_up_active.png';
 import deLikeIco from '../assets/ico_thumbs_down.png';
 import deLikeActiveIco from '../assets/ico_thumbs_down_active.png';
 import { useState } from 'react';
+import { postReaction } from '../utill/api';
 
 const ReactionArea = styled.div`
   display: flex;
@@ -40,6 +41,7 @@ const ReactionArea = styled.div`
 `;
 
 function Reaction({
+  questionId,
   likeActive = false,
   deLikeActive = false,
   likeNumber = 0,
@@ -51,30 +53,33 @@ function Reaction({
   const [isDeLikeActive, setDeIsLikeActive] = useState(deLikeActive);
   const [likeEa, setLikeEa] = useState(likeNumber);
   const [deLikeEa, setDeLikeEa] = useState(deLikeNumber);
+  const [busy, setBusy] = useState(false); // API 요청 중에는 버튼 비활성화
 
-  const onClickLike = () => {
-    if (isLikeActive) {
-      setLikeEa(Number(likeEa) - 1);
-    } else {
-      setLikeEa(Number(likeEa) + 1);
-    }
+  const onClickLike = async () => {
+    if (busy) return;
     setIsLikeActive(!isLikeActive);
-
-    if (likeClick) {
-      likeClick();
+    setBusy(true);
+    try {
+      if (!isLikeActive) await postReaction(questionId, 'like');
+      setLikeEa(isLikeActive ? likeEa - 1 : likeEa + 1);
+    } catch (e) {
+      alert(`좋아요 실패: ${e?.message || ''}`);
+    } finally {
+      setBusy(false);
     }
   };
 
-  const onClickDeLike = () => {
-    if (isDeLikeActive) {
-      setDeLikeEa(Number(deLikeEa) - 1);
-    } else {
-      setDeLikeEa(Number(deLikeEa) + 1);
-    }
+  const onClickDeLike = async () => {
+    if (busy) return;
     setDeIsLikeActive(!isDeLikeActive);
-
-    if (deLikeClick) {
-      deLikeClick();
+    setBusy(true);
+    try {
+      if (!isDeLikeActive) await postReaction(questionId, 'dislike');
+      setDeLikeEa(isDeLikeActive ? deLikeEa - 1 : deLikeEa + 1);
+    } catch (e) {
+      alert(`싫어요 실패: ${e?.message || ''}`);
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -83,6 +88,7 @@ function Reaction({
       <button
         className={`like ${isLikeActive ? 'active' : ''}`}
         onClick={onClickLike}
+        disabled={busy}
       >
         <img src={isLikeActive ? likeActiveIco : likeIco} alt="좋아요 아이콘" />
         좋아요 {likeEa <= 0 ? '' : likeEa}
@@ -90,6 +96,7 @@ function Reaction({
       <button
         className={isDeLikeActive ? 'active' : ''}
         onClick={onClickDeLike}
+        disabled={busy}
       >
         <img
           src={isDeLikeActive ? deLikeActiveIco : deLikeIco}

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -2,9 +2,14 @@ import FeedCardGroup from '../components/FeedCard/FeedCardGroup';
 import styled from 'styled-components';
 import CircleImage from '../components/Profile';
 import Button from '../components/Button';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { deleteQuestionsBySubject } from '../utill/api';
 
 function Answer({ userImage = '/cat.jpg', userName = '아초는고양이' }) {
+  const { id: subjectId } = useParams(); // URL에서 subjectId 추출 (예: /post/:id/answer)
+  const [deleting, setDeleting] = useState(false); // 전체 삭제하기 버튼 상태
+
   const [items, setItems] = useState([
     {
       questionProps: {
@@ -69,10 +74,22 @@ function Answer({ userImage = '/cat.jpg', userName = '아초는고양이' }) {
       <Content>
         <RightBar>
           <Button
-            width="100px"
+            width="120px"
             height="35px"
             type="insert"
-            onClick={() => setItems([])}
+            disabled={deleting}
+            onClick={async () => {
+              if (deleting) return;
+              try {
+                setDeleting(true);
+                await deleteQuestionsBySubject(subjectId); // 전체 삭제하기 API 호출
+                setQuestions([]);
+              } catch (e) {
+                alert(`삭제 실패: ${e?.message || ''}`);
+              } finally {
+                setDeleting(false);
+              }
+            }}
           >
             전체 삭제하기
           </Button>
@@ -107,6 +124,7 @@ const Banner = styled.div`
 
 const Logo = styled.img`
   margin-top: 50px;
+  margin-bottom: 12px;
   height: 67px; /* 필요 시 조절 */
   width: auto;
 `;

--- a/src/utill/api.js
+++ b/src/utill/api.js
@@ -1,1 +1,156 @@
 const BASE_URL = 'https://openmind-api.vercel.app/19-9/';
+
+/********* ANSWERS *********/
+
+// GET /{team}/answers/{id}/
+export async function getAnswer(answerId) {
+  const res = await fetch(`${BASE_URL}answers/${answerId}/`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+// PUT /{team}/answers/{id}/
+
+// PATCH /{team}/answers/{id}/
+export async function patchAnswer(answerId, content, isRejected = false) {
+  const res = await fetch(`${BASE_URL}answers/${answerId}/`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ content, isRejected }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+// DELETE /{team}/answers/{id}/
+
+/********* QUESTIONS *********/
+
+// GET /{team}/questions/{id}/
+export async function getQuestion(questionId) {
+  const res = await fetch(`${BASE_URL}questions/${questionId}/`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+// DELETE /{team}/questions/{id}/
+export async function deleteQuestion(questionId) {
+  const res = await fetch(`${BASE_URL}questions/${questionId}/`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return true;
+}
+
+// POST /{team}/questions/{id}/reaction/
+export async function postReaction(questionId, type) {
+  const res = await fetch(`${BASE_URL}questions/${questionId}/reaction/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ type }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+// POST /{team}/questions/{question_id}/answers/
+export async function postAnswer(questionId, content, isRejected = false) {
+  const res = await fetch(`${BASE_URL}questions/${questionId}/answers/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ content, isRejected }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+/********* SUBJECTS *********/
+
+// GET /{team}/subjects/
+export async function getSubjects() {
+  const res = await fetch(`${BASE_URL}subjects/`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+// POST /{team}/subjects/
+
+// GET /{team}/subjects/{id}/
+export async function getSubject(subjectId) {
+  const res = await fetch(`${BASE_URL}subjects/${subjectId}/`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+// DELETE /{team}/subjects/{id}/
+
+// GET /{team}/subjects/{subject_id}/questions/
+export async function getQuestionsBySubject(subjectId) {
+  const res = await fetch(`${BASE_URL}subjects/${subjectId}/questions/`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+// POST /{team}/subjects/{subject_id}/questions/
+export async function postQuestion(subjectId, content) {
+  const res = await fetch(`${BASE_URL}subjects/${subjectId}/questions/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ content }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${text}`);
+  }
+  return res.json();
+}
+
+// Answer 페이지 '전체 삭제하기' 기능
+export async function deleteQuestionsBySubject(subjectId) {
+  const res = await getQuestionsBySubject(subjectId);
+  const list = Array.isArray(res?.results) ? res.results : [];
+  await Promise.all(list.map((el) => deleteQuestion(el.id)));
+}


### PR DESCRIPTION
## 📝 요약(Summary)

기존 [이동국] Answer 페이지 API 기능 추가 및 적용 #56 PR 기능별로 분할 중입니다!
* API swagger 기능 10종 추가
* 좋아요/싫어요 클릭시 리액션 POST 요청 후 처리
* 전체 삭제하기 클릭시 기능 추가 및 적용

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

* `api.js`
-swagger API 10종 추가
https://openmind-api.vercel.app/docs/
answers(GET, PATCH, DELETE)
questions(GET, DELETE, POST/reactions, POST/answers)
subjects(GET/subjects, GET/subjects/{id}, GET/questions, POST)

-Answer 페이지 '전체 삭제하기' 기능 API 추가

* `reaction.jsx`
-좋아요/싫어요 버튼 활성화 시 POST/reactions 요청 보내기

* `Answer.jsx`
- subjectId 추출
<img width="615" height="23" alt="image" src="https://github.com/user-attachments/assets/976aef6b-d4ec-4397-82f3-979fd7894606" />

- 전체 삭제하기 기능 적용

## 기타
-현재는 Answer 페이지에서 reactionProps을 넘기지 않기 때문에 questionId가 undefined되어 postReaction이 적용되지 않습니다.

-한 명당 좋아요/싫어요 최대 수가 1이 되어야 할 것 같은데 현재는 한 명이 여러번 좋아요/싫어요를 보낼 수 있습니다. api에는 좋아요/싫어요 +1만 보내는 요청이 존재합니다. 어떻게 수정할 수 있을까요? (멘토님에게 질문하기)

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
