### PR TITLE
[이동국] id에 따른 데이터 불러오기, 상대시간 업데이트, 기타 리팩토링 #56-2

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -107,8 +107,7 @@ function Button({
   height = '',
   type = '',
   children,
-  disabled,
-  onClick,
+  ...rest // disabled, onClick
 }) {
   const defaultText =
     type === 'answer'
@@ -122,21 +121,11 @@ function Button({
   return (
     <div>
       {type === 'insert' ? (
-        <InsertButton
-          width={width}
-          height={height}
-          disabled={disabled}
-          onClick={onClick}
-        >
+        <InsertButton width={width} height={height} {...rest}>
           {children || defaultText}
         </InsertButton>
       ) : (
-        <BaseButton
-          width={width}
-          height={height}
-          type={type}
-          disabled={disabled}
-        >
+        <BaseButton width={width} height={height} type={type} {...rest}>
           {children || defaultText}
 
           {iconTypes.includes(type) && (

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -80,6 +80,7 @@ export default function FeedCard({
   answerProps = {},
   reactionProps = {},
   hideAnswer = false,
+  onDeleted = () => {},
 }) {
   const [showPopup, setShowPopup] = useState(false);
   const [isEditing, setIsEditing] = useState(false);

--- a/src/components/FeedCard/FeedCardAnswer.jsx
+++ b/src/components/FeedCard/FeedCardAnswer.jsx
@@ -1,9 +1,8 @@
-import styled from 'styled-components'
-import Profile from '../Profile'
-import InputTextArea from '../InputTextArea'
-import ButtonBox from '../ButtonBox'
-import { useState, useEffect } from 'react'
-import CircleImage from '../Profile'
+import styled from 'styled-components';
+import InputTextArea from '../InputTextArea';
+import ButtonBox from '../ButtonBox';
+import { useState, useEffect } from 'react';
+import CircleImage from '../Profile';
 
 // 공통 카드 스타일
 const Card = styled.div`
@@ -15,33 +14,35 @@ const Card = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
-`
+`;
 
 const ProfileRow = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 8px;
-`
+`;
 
 const UserName = styled.span`
   font-weight: 600;
   font-size: 16px;
   color: #222;
-`
+`;
 
 const TimeAgo = styled.span`
   font-size: 13px;
   color: #bdb0a7;
-`
+`;
 
 const StyledButtonWrap = styled.div`
   margin-top: 8px;
   display: flex;
   gap: 8px;
-`
+`;
 
 export default function FeedCardAnswer({
+  questionId,
+  answerId,
   state = 'pending',
   answer = '답변 내용',
   userImage = '/cat.png',
@@ -49,17 +50,19 @@ export default function FeedCardAnswer({
   timeAgo = '2주 전',
   editing = false,
   onSave,
+  onCancel,
+  onStateChange,
 }) {
-  const [input, setInput] = useState('')
+  const [input, setInput] = useState('');
 
   useEffect(() => {
     // 편집 모드로 들어갈 때 기존 답변을 입력창에 채워줌
-    if (editing) setInput(answer || '')
-  }, [editing, answer])
+    if (editing) setInput(answer || '');
+  }, [editing, answer]);
 
-  const isRejected = state === 'rejected'
-  const canEdit = !isRejected && (state === 'pending' || editing)
-  const isButtonActive = input.trim().length > 0
+  const isRejected = state === 'rejected';
+  const canEdit = !isRejected && (state === 'pending' || editing);
+  const isButtonActive = input.trim().length > 0;
 
   return (
     <Card>
@@ -88,8 +91,8 @@ export default function FeedCardAnswer({
               style={{ width: '100%' }}
               disabled={!isButtonActive}
               onClick={() => {
-                if (!isButtonActive) return
-                if (onSave) onSave(input.trim())
+                if (!isButtonActive) return;
+                if (onSave) onSave(input.trim());
               }}
             >
               {state === 'pending'
@@ -119,5 +122,5 @@ export default function FeedCardAnswer({
         <div style={{ color: 'red', fontSize: '16px' }}>답변 거절</div>
       )}
     </Card>
-  )
+  );
 }

--- a/src/components/FeedCard/FeedCardGroup.jsx
+++ b/src/components/FeedCard/FeedCardGroup.jsx
@@ -40,9 +40,8 @@ const Empty = styled.img`
   margin: auto;
 `;
 
-// items: [{ id?, subjectId?, questionProps, answerProps, reactionProps, hideAnswer }]
-export default function FeedCardGroup({ items, count }) {
-  if (!items?.length) {
+export default function FeedCardGroup({ questions = [], onChange }) {
+  if (!questions?.length) {
     return (
       <GroupWrap>
         <Banner>
@@ -58,17 +57,17 @@ export default function FeedCardGroup({ items, count }) {
     <GroupWrap>
       <Banner>
         <img src="/Messages.svg" alt="Messages" />
-        {count}개의 질문이 있습니다
+        {questions.length}개의 질문이 있습니다
       </Banner>
 
-      {items.map((item, idx) => (
+      {questions.map((q) => (
         <FeedCard
-          key={item.id ?? idx}
-          subjectId={item.subjectId}
-          questionProps={item.questionProps}
-          answerProps={item.answerProps}
-          reactionProps={item.reactionProps}
-          hideAnswer={item.hideAnswer}
+          key={q.id}
+          subjectId={q.subjectId}
+          questionProps={q.questionProps}
+          answerProps={q.answerProps}
+          reactionProps={q.reactionProps}
+          hideAnswer={q.hideAnswer}
         />
       ))}
     </GroupWrap>

--- a/src/components/FeedCard/FeedCardGroup.jsx
+++ b/src/components/FeedCard/FeedCardGroup.jsx
@@ -1,5 +1,5 @@
-import styled from 'styled-components'
-import FeedCard from './FeedCard'
+import styled from 'styled-components';
+import FeedCard from './FeedCard';
 
 const GroupWrap = styled.div`
   width: 100%;
@@ -14,7 +14,7 @@ const GroupWrap = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 16px;
-`
+`;
 
 const Banner = styled.div`
   display: flex;
@@ -30,7 +30,7 @@ const Banner = styled.div`
   font-style: normal;
   font-weight: 400;
   line-height: 125%;
-`
+`;
 
 const Empty = styled.img`
   width: 25%;
@@ -38,40 +38,39 @@ const Empty = styled.img`
   justify-content: center;
   align-items: center;
   margin: auto;
-`
+`;
 
 // items: [{ id?, subjectId?, questionProps, answerProps, reactionProps, hideAnswer }]
 export default function FeedCardGroup({ items, count }) {
+  if (!items?.length) {
+    return (
+      <GroupWrap>
+        <Banner>
+          <img src="/Messages.svg" alt="Messages" />
+          아직 질문이 없습니다
+        </Banner>
+        <Empty src="/empty.svg" alt="empty" />
+      </GroupWrap>
+    );
+  }
+
   return (
     <GroupWrap>
       <Banner>
-        {items?.length > 0 ? (
-          <>
-            <img src="/Messages.svg" alt="Messages" />
-            {count}개의 질문이 있습니다
-          </>
-        ) : (
-          <>
-            <img src="/Messages.svg" alt="Messages" />
-            아직 질문이 없습니다
-          </>
-        )}
+        <img src="/Messages.svg" alt="Messages" />
+        {count}개의 질문이 있습니다
       </Banner>
 
-      {items?.length > 0 ? (
-        items.map((item, idx) => (
-          <FeedCard
-            key={item.id ?? idx}
-            subjectId={item.subjectId}
-            questionProps={item.questionProps}
-            answerProps={item.answerProps}
-            reactionProps={item.reactionProps}
-            hideAnswer={item.hideAnswer}
-          />
-        ))
-      ) : (
-        <Empty src="/empty.svg" alt="empty" />
-      )}
+      {items.map((item, idx) => (
+        <FeedCard
+          key={item.id ?? idx}
+          subjectId={item.subjectId}
+          questionProps={item.questionProps}
+          answerProps={item.answerProps}
+          reactionProps={item.reactionProps}
+          hideAnswer={item.hideAnswer}
+        />
+      ))}
     </GroupWrap>
-  )
+  );
 }

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -9,6 +9,7 @@ import { deleteQuestionsBySubject } from '../utill/api';
 function Answer({ userImage = '/cat.jpg', userName = '아초는고양이' }) {
   const { id: subjectId } = useParams(); // URL에서 subjectId 추출 (예: /post/:id/answer)
   const [deleting, setDeleting] = useState(false); // 전체 삭제하기 버튼 상태
+  const [questions, setQuestions] = useState([]);
 
   const [items, setItems] = useState([
     {

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -4,62 +4,43 @@ import CircleImage from '../components/Profile';
 import Button from '../components/Button';
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { deleteQuestionsBySubject } from '../utill/api';
+import { deleteQuestionsBySubject, postQuestion } from '../utill/api';
+import { loadQuestionsBySubject as loadData } from '../utill/load';
 
-function Answer({ userImage = '/cat.jpg', userName = '아초는고양이' }) {
+function Answer() {
   const { id: subjectId } = useParams(); // URL에서 subjectId 추출 (예: /post/:id/answer)
   const [deleting, setDeleting] = useState(false); // 전체 삭제하기 버튼 상태
+  const [subject, setSubject] = useState(null);
   const [questions, setQuestions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  const [items, setItems] = useState([
-    {
-      questionProps: {
-        question: '좋아하는 동물?',
-        timeAgo: '2주전',
-        state: 'pending',
-      },
-      answerProps: { state: 'pending', userImage, userName },
-    },
-    {
-      questionProps: {
-        question: '좋아하는 동물은?',
-        timeAgo: '2주전',
-        state: 'pending',
-      },
-      answerProps: { state: 'pending', userImage, userName },
-    },
-    {
-      questionProps: {
-        question:
-          '좋아하는 동물은?좋아하는 동물은?좋아하는 동물은? 좋아하동 물은?',
-        timeAgo: '2주전',
-        state: 'answered',
-      },
-      answerProps: {
-        state: 'answered',
-        userName,
-        timeAgo: '2주전',
-        answer:
-          '그릇을 몰라 귀는 이상 오직 피고, 가슴이 이상, 못할 범바람이다. 찾아다녀도, 젖인 방향하였다.',
-      },
-    },
-    {
-      questionProps: {
-        question:
-          '좋아하는 동물은?좋아하는 동물은?좋아하는 동물은? 좋아하동 물은?',
-        timeAgo: '2주전',
-        state: 'answered',
-      },
-      answerProps: { state: 'rejected', userName, timeAgo: '2주전' },
-    },
-    {
-      questionProps: {
-        question: '좋아하는 동물은?',
-        timeAgo: '2주전',
-        state: 'pending',
-      },
-    },
-  ]);
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      if (!subjectId) return;
+      try {
+        setLoading(true);
+        setError(null);
+        const { subject: s, questions: q } = await loadData(subjectId);
+        if (!mounted) return;
+        setSubject(s);
+        setQuestions(q);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e);
+      } finally {
+        if (!mounted) return;
+        setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [subjectId]);
+
+  if (loading) return <div style={{ padding: 16 }}>로딩 중…</div>;
+  if (error) return <div style={{ padding: 16 }}>불러오기에 실패했습니다.</div>;
 
   return (
     <div>
@@ -67,8 +48,8 @@ function Answer({ userImage = '/cat.jpg', userName = '아초는고양이' }) {
         <Banner />
         <Logo src="/logo.png" alt="OpenMind" />
 
-        <CircleImage src={userImage} sizes="136px" />
-        <UserName>{userName}</UserName>
+        <CircleImage src={subject?.imageSource} sizes="136px" />
+        <UserName>{subject?.name}</UserName>
         {/* Button/share 컴포넌트 위치 */}
       </TopRow>
 
@@ -95,7 +76,10 @@ function Answer({ userImage = '/cat.jpg', userName = '아초는고양이' }) {
             전체 삭제하기
           </Button>
         </RightBar>
-        <FeedCardGroup items={items} count={items.length} />
+        <FeedCardGroup
+          questions={questions}
+          onChange={(next) => setQuestions(next)}
+        />
       </Content>
     </div>
   );

--- a/src/utill/api.js
+++ b/src/utill/api.js
@@ -153,4 +153,5 @@ export async function deleteQuestionsBySubject(subjectId) {
   const res = await getQuestionsBySubject(subjectId);
   const list = Array.isArray(res?.results) ? res.results : [];
   await Promise.all(list.map((el) => deleteQuestion(el.id)));
+  return true;
 }

--- a/src/utill/load.js
+++ b/src/utill/load.js
@@ -1,0 +1,54 @@
+import { getSubject, getQuestionsBySubject } from './api';
+import { formatRelativeTime } from './time';
+
+export async function loadQuestionsBySubject(subjectId) {
+  if (!subjectId) return { subject: null, questions: [] };
+
+  const [s, q] = await Promise.all([
+    getSubject(subjectId),
+    getQuestionsBySubject(subjectId),
+  ]);
+
+  const list = Array.isArray(q?.results)
+    ? q.results
+    : Array.isArray(q)
+      ? q
+      : [];
+
+  const mappedQuestions = list.map((q) => {
+    const questionTime = formatRelativeTime(q.createdAt);
+    const answerTime = q.answer ? formatRelativeTime(q.answer.createdAt) : null;
+
+    return {
+      id: q.id,
+      questionProps: {
+        id: q.id,
+        question: q.content,
+        timeAgo: questionTime,
+      },
+      answerProps: q.answer
+        ? {
+            answerId: q.answer.id,
+            state: q.answer.isRejected ? 'rejected' : 'answered',
+            userName: s?.name,
+            userImage: s?.imageSource,
+            timeAgo: answerTime,
+            answer: q.answer.content,
+          }
+        : {
+            state: 'pending',
+            userName: s?.name,
+            userImage: s?.imageSource,
+            timeAgo: null,
+            answer: '',
+          },
+      reactionProps: {
+        questionId: q.id,
+        likeNumber: q.like ?? 0,
+        deLikeNumber: q.dislike ?? 0,
+      },
+    };
+  });
+
+  return { subject: s, questions: mappedQuestions };
+}

--- a/src/utill/time.js
+++ b/src/utill/time.js
@@ -1,0 +1,20 @@
+// 상대시간 포맷터: ISO 시간을 받아 '방금/분/시간/일/주/개월/년 전'으로 변환
+export function formatRelativeTime(isoString) {
+  if (!isoString) return '방금';
+  const then = new Date(isoString).getTime();
+  if (Number.isNaN(then)) return '방금';
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (diffSec < 60) return '방금';
+  const mins = Math.floor(diffSec / 60);
+  if (mins < 60) return `${mins}분 전`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}일 전`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}주 전`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}개월 전`;
+  const years = Math.floor(days / 365);
+  return `${years}년 전`;
+}


### PR DESCRIPTION
## 📝 요약(Summary)

https://github.com/user-attachments/assets/80bd4a81-5146-48a7-ac19-9bea1826919b

기존  [이동국] Answer 페이지 API 기능 추가 및 적용 https://github.com/looks32/codeit-openmind/pull/56 PR 기능별로 분할 중입니다!
* subjectId에 따라 Answer 페이지의 subject 데이터와 questions 데이터 불러오기 (load.js)
* 현재 시간과 생성 시간을 비교해 질응답의 상대시간 나타내기 (time.js)
* Answer 페이지에서 위 두 기능 적용하기
* FeedCard 3개 파일 props 업데이트
* [이동국] Answer 수정하기 및 전체 삭제하기 기능 추가 #49 PR 피드백 반영한 코드 리팩토링

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

`Button.jsx`
- (리팩토링) Disabled, onClick props -> Rest props으로 변경

`FeedCard.jsx`
- (Chore) onDelete props 추가

`FeedCardAnswer.jsx`
- (Chore) questionId, answerId, onCancel, onStateChange. Props 추가

`FeedCardGroup.jsx`
- (리팩토링) 아이템(question)이 없을때 얼리리턴문으로 처리
- (Update) Items, count props -> questions, onChange props로 변경

`Answer.jsx`
- (Feat) 목업 데이터에서 실제 API 요청을 통해 서버로 가져온 데이터 불러오기
- (Feat) 불러온 데이터 처리

`load.js`
- (Feat) api.js에서 subject 데이터와 questions 데이터를 가져와 FeedCardGroup의 props에 전달하기 위해 매핑하기

`time.js`
- (Feat) 현재시간 - 생성시간에 따른 상대시간 나타내기

`api.js`
- (오류 수정) 빠진 return 문 추가

## 기타
- 이전 PR인 [이동국] reaction, 전체 삭제하기 API 기능 적용 #58이 정상 동작할 것입니다!

앞으로 
* 미답변 FeedCard 답변 완료시 답변 POST 요청 후 처리
* 삭제하기 클릭시 해당 질문 DELETE 요청 후 처리
* 수정하기 클릭 후 수정 완료시 답변 PATCH 요청 후 처리
위 3가지 추가하면 [이동국] Answer 페이지 API 기능 추가 및 적용 https://github.com/looks32/codeit-openmind/pull/56 PR 기능은 전부 추가됩니다!

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
